### PR TITLE
Update guide.rst

### DIFF
--- a/source/guide.rst
+++ b/source/guide.rst
@@ -527,9 +527,6 @@ Configure `acl_query` and `acl_nomatch` in etc/plugins/emq_auth_mongo.conf:
 
     auth.mongo.acl_query.selector = username=%u
 
-    ## acl_nomatch
-    auth.mongo.acl_nomatch = deny
-
 ----------------------
 MQTT Publish/Subscribe
 ----------------------


### PR DESCRIPTION
This parameter has been removed. And ACL rules still work fine.
Adding this parameter crashes emqtt broker.