### PR TITLE
Docs/clarify auth ordering

### DIFF
--- a/source/guide.rst
+++ b/source/guide.rst
@@ -15,7 +15,7 @@ The authentication is provided by a list of plugins such as MySQL, PostgreSQL an
 
 If we enable several authentication plugins at the same time, the Auth request will be forwarded to next auth module
 
-the authentication process::
+The authentication flow::
 
               ---------------            --------------            ---------------
   Client --> |  Redis Auth   | -ignore-> |  HTTP Auth  | -ignore-> |  MySQL Auth  |

--- a/source/guide.rst
+++ b/source/guide.rst
@@ -13,14 +13,19 @@ The *EMQ* broker supports to authenticate MQTT clients with ClientID, Username/P
 
 The authentication is provided by a list of plugins such as MySQL, PostgreSQL and Redis...
 
-If we enable several authentication plugins at the same time, the authentication process::
+If we enable several authentication plugins at the same time, the Auth request will be forwarded to next auth module
 
-               ----------------           ----------------           -------------
-    Client --> |   Username   | -ignore-> |   ClientID   | -ignore-> | Anonymous |
-               ----------------           ----------------           -------------
-                      |                         |                         |
-                     \|/                       \|/                       \|/
-                allow | deny              allow | deny              allow | deny
+the authentication process::
+
+              ---------------            --------------            ---------------
+  Client --> |  Redis Auth   | -ignore-> |  HTTP Auth  | -ignore-> |  MySQL Auth  |
+              ---------------            --------------            ---------------
+                    |                           |                         |
+                   \|/                         \|/                       \|/
+              allow | deny                allow | deny              allow | deny
+
+
+The order that the authentication will be carried out is determined by the order that the plugins are loaded (their order in `data/loaded_plugins`) 
 
 The authentication plugins implemented by default:
 

--- a/source/guide.rst
+++ b/source/guide.rst
@@ -25,7 +25,7 @@ the authentication process::
               allow | deny                allow | deny              allow | deny
 
 
-The order that the authentication will be carried out is determined by the order that the plugins are loaded (their order in ``data/loaded_plugins``) 
+The order that the authentication will be carried out is determined by the order that the plugins are loaded (their order in ``./data/loaded_plugins``) 
 
 The authentication plugins implemented by default:
 

--- a/source/guide.rst
+++ b/source/guide.rst
@@ -25,7 +25,7 @@ the authentication process::
               allow | deny                allow | deny              allow | deny
 
 
-The order that the authentication will be carried out is determined by the order that the plugins are loaded (their order in ``./data/loaded_plugins``) 
+The order that the authentication will be carried out is determined by the order that the plugins are loaded (their order of appearance in ``./data/loaded_plugins``) 
 
 The authentication plugins implemented by default:
 

--- a/source/guide.rst
+++ b/source/guide.rst
@@ -25,7 +25,7 @@ the authentication process::
               allow | deny                allow | deny              allow | deny
 
 
-The order that the authentication will be carried out is determined by the order that the plugins are loaded (their order in `data/loaded_plugins`) 
+The order that the authentication will be carried out is determined by the order that the plugins are loaded (their order in ``data/loaded_plugins``) 
 
 The authentication plugins implemented by default:
 


### PR DESCRIPTION
I was investigating using multiple authentication modules today, 

I had trouble understanding how it works...
I found a very good explanation on how it works by @emqplus in https://github.com/emqtt/emqttd/issues/889

I thought it might be a good idea to add his explanation to the docs
